### PR TITLE
refactor: replace anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,6 @@ dependencies = [
 name = "dnrs"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ opt-level = 0
 lto = false
 
 [dependencies]
-anyhow = "1.0.99"
 async-trait = "0.1.89"
 clap = { version = "4.5.39", features = ["derive", "unicode", "wrap_help"] }
 dirs = "6.0.0"

--- a/src/cli/generate_config.rs
+++ b/src/cli/generate_config.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use lum_log::info;
 use thiserror::Error;
 
-use crate::{Config, cli::ExecutableCommand};
+use crate::{Config, ConfigError, cli::ExecutableCommand};
 
 #[derive(Debug)]
 pub struct Input<'config> {
@@ -20,7 +20,7 @@ pub enum Error {
     Yaml(#[from] serde_yaml_ng::Error),
 
     #[error("Config error: {0}")]
-    Config(#[from] anyhow::Error),
+    Config(#[from] ConfigError),
 }
 
 /// Generate configuration directory structure

--- a/src/cli/get.rs
+++ b/src/cli/get.rs
@@ -26,7 +26,7 @@ pub enum Error {
     ProviderNotConfigured(String),
 
     #[error("Provider error: {0}")]
-    ProviderError(#[from] ProviderError),
+    Provider(#[from] ProviderError),
 
     #[error("Cannot specify both --all and specific subdomains")]
     ConflictingArguments,

--- a/src/cli/get.rs
+++ b/src/cli/get.rs
@@ -9,7 +9,7 @@ use crate::{
     cli::ExecutableCommand,
     config::provider::Provider as ProviderConfig,
     provider::{
-        GetAllRecordsInput, GetRecordsInput, Provider, hetzner::HetznerProvider,
+        GetAllRecordsInput, GetRecordsInput, Provider, ProviderError, hetzner::HetznerProvider,
         netcup::NetcupProvider, nitrado::NitradoProvider,
     },
 };
@@ -26,7 +26,13 @@ pub enum Error {
     ProviderNotConfigured(String),
 
     #[error("Provider error: {0}")]
-    ProviderError(#[from] anyhow::Error),
+    ProviderError(#[from] ProviderError),
+
+    #[error("Cannot specify both --all and specific subdomains")]
+    ConflictingArguments,
+
+    #[error("Must specify either --all or specific subdomains")]
+    MissingArguments,
 }
 
 #[derive(Debug, Args)]
@@ -94,16 +100,12 @@ impl<'command> ExecutableCommand<'command> for Command<'command> {
     async fn execute(&self, input: &'command Self::I) -> Self::R {
         if self.subdomain_args.all && !self.subdomain_args.subdomains.is_empty() {
             error!("Cannot specify both --all and specific subdomains");
-            return Err(Error::ProviderError(anyhow::anyhow!(
-                "Cannot specify both --all and specific subdomains"
-            )));
+            return Err(Error::ConflictingArguments);
         }
 
         if !self.subdomain_args.all && self.subdomain_args.subdomains.is_empty() {
             error!("Must specify either --all or specific subdomains");
-            return Err(Error::ProviderError(anyhow::anyhow!(
-                "Must specify either --all or specific subdomains"
-            )));
+            return Err(Error::MissingArguments);
         }
 
         let config = input.config;

--- a/src/cli/get.rs
+++ b/src/cli/get.rs
@@ -158,11 +158,13 @@ mod tests {
 
     #[test]
     fn test_get_provider_nitrado() {
-        let mut config = Config::default();
-        config.providers = vec![ProviderConfig::Nitrado(nitrado::Config {
-            name: "TestNitrado".to_string(),
+        let config = Config {
+            providers: vec![ProviderConfig::Nitrado(nitrado::Config {
+                name: "TestNitrado".to_string(),
+                ..Default::default()
+            })],
             ..Default::default()
-        })];
+        };
 
         let provider = get_provider("TestNitrado", &config).unwrap();
         assert_eq!(provider.get_provider_name(), "Nitrado");
@@ -170,11 +172,13 @@ mod tests {
 
     #[test]
     fn test_get_provider_hetzner() {
-        let mut config = Config::default();
-        config.providers = vec![ProviderConfig::Hetzner(hetzner::Config {
-            name: "TestHetzner".to_string(),
+        let config = Config {
+            providers: vec![ProviderConfig::Hetzner(hetzner::Config {
+                name: "TestHetzner".to_string(),
+                ..Default::default()
+            })],
             ..Default::default()
-        })];
+        };
 
         let provider = get_provider("TestHetzner", &config).unwrap();
         assert_eq!(provider.get_provider_name(), "Hetzner");
@@ -182,11 +186,13 @@ mod tests {
 
     #[test]
     fn test_get_provider_netcup() {
-        let mut config = Config::default();
-        config.providers = vec![ProviderConfig::Netcup(netcup::Config {
-            name: "TestNetcup".to_string(),
+        let config = Config {
+            providers: vec![ProviderConfig::Netcup(netcup::Config {
+                name: "TestNetcup".to_string(),
+                ..Default::default()
+            })],
             ..Default::default()
-        })];
+        };
 
         let provider = get_provider("TestNetcup", &config).unwrap();
         assert_eq!(provider.get_provider_name(), "Netcup");

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 #[test]
 fn test_help() {
     let output = Command::new("cargo")
-        .args(&["run", "--", "--help"])
+        .args(["run", "--", "--help"])
         .output()
         .expect("failed to execute process");
 
@@ -16,7 +16,7 @@ fn test_help() {
 #[test]
 fn test_generate_config_help() {
     let output = Command::new("cargo")
-        .args(&["run", "--", "generate-config", "--help"])
+        .args(["run", "--", "generate-config", "--help"])
         .output()
         .expect("failed to execute process");
 
@@ -33,7 +33,7 @@ fn test_generate_config_execution() {
     }
 
     let output = Command::new("cargo")
-        .args(&[
+        .args([
             "run",
             "--",
             "generate-config",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,8 @@
-//TODO: No anyhow
-use anyhow::Result;
 use lum_config::MergeFrom;
 use lum_libs::serde::{Deserialize, Serialize};
-use lum_log::{debug, error, info};
-use std::{fs, path::Path};
+use lum_log::{debug, info};
+use std::{fs, io, path::Path};
+use thiserror::Error;
 
 use crate::{
     config::provider::Provider,
@@ -13,6 +12,22 @@ use crate::{
 pub mod dns;
 pub mod provider;
 pub mod resolver;
+
+/// Error type for configuration loading and parsing.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("YAML parsing error: {0}")]
+    Yaml(#[from] serde_yaml_ng::Error),
+
+    #[error("Unknown provider config file: {0}")]
+    UnknownProvider(String),
+
+    #[error("Cannot determine DNS config type for file: {0}")]
+    UnknownDnsType(String),
+}
 
 /// Configuration for the dnrs application.
 ///
@@ -28,7 +43,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn load_from_directory(config_dir: impl AsRef<Path>) -> Result<Self> {
+    pub fn load_from_directory(config_dir: impl AsRef<Path>) -> Result<Self, ConfigError> {
         let config_dir = config_dir.as_ref();
         let resolver = Self::load_resolver_config(config_dir)?;
         let providers = Self::load_provider_configs(&config_dir.join("providers"))?;
@@ -44,7 +59,7 @@ impl Config {
         Ok(default_config.merge_from(loaded_config))
     }
 
-    fn load_resolver_config(config_dir: impl AsRef<Path>) -> Result<resolver::Config> {
+    fn load_resolver_config(config_dir: impl AsRef<Path>) -> Result<resolver::Config, ConfigError> {
         let resolver_path = config_dir.as_ref().join("resolver.yaml");
 
         //TODO: Fail with error if resolver config is missing
@@ -56,7 +71,7 @@ impl Config {
         }
     }
 
-    fn load_provider_configs(providers_dir: impl AsRef<Path>) -> Result<Vec<Provider>> {
+    fn load_provider_configs(providers_dir: impl AsRef<Path>) -> Result<Vec<Provider>, ConfigError> {
         let providers_dir = providers_dir.as_ref();
         //TODO: Fail with error if providers config is missing
         if !providers_dir.exists() {
@@ -105,7 +120,7 @@ impl Config {
                         debug!("Loaded Netcup provider config from {:?}", path);
                     }
                     _ => {
-                        error!("Unknown provider config file: {}", path.display());
+                        return Err(ConfigError::UnknownProvider(path.display().to_string()));
                     }
                 }
             }
@@ -120,7 +135,7 @@ impl Config {
         Ok(configs)
     }
 
-    fn load_dns_configs(dns_dir: impl AsRef<Path>) -> Result<Vec<dns::Type>> {
+    fn load_dns_configs(dns_dir: impl AsRef<Path>) -> Result<Vec<dns::Type>, ConfigError> {
         let dns_dir = dns_dir.as_ref();
 
         //TODO: Fail with error if dns config is missing
@@ -162,10 +177,7 @@ impl Config {
                     configs.push(dns::Type::Netcup(config));
                     debug!("Loaded Netcup DNS config from {:?}", path);
                 } else {
-                    error!(
-                        "Cannot determine DNS config type for file: {}",
-                        path.display()
-                    );
+                    return Err(ConfigError::UnknownDnsType(path.display().to_string()));
                 }
             }
         }
@@ -174,7 +186,7 @@ impl Config {
         Ok(configs)
     }
 
-    pub fn create_example_structure(config_dir: impl AsRef<Path>) -> Result<()> {
+    pub fn create_example_structure(config_dir: impl AsRef<Path>) -> Result<(), ConfigError> {
         let config_dir = config_dir.as_ref();
 
         fs::create_dir_all(config_dir.join("providers"))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -251,6 +251,41 @@ impl Default for Config {
     }
 }
 
+impl MergeFrom<Self> for Config {
+    /// Merges another configuration into this one.
+    ///
+    /// Values from `other` will override values in `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dnrs::Config;
+    /// use lum_config::MergeFrom;
+    ///
+    /// let mut config = Config::default();
+    /// let mut other = Config::default();
+    /// other.resolver.ipv4.url = "https://example.com".to_string();
+    ///
+    /// let merged = config.merge_from(other);
+    /// assert_eq!(merged.resolver.ipv4.url, "https://example.com");
+    /// ```
+    fn merge_from(self, other: Self) -> Self {
+        Self {
+            resolver: other.resolver,
+            providers: if !other.providers.is_empty() {
+                other.providers
+            } else {
+                self.providers
+            },
+            dns: if !other.dns.is_empty() {
+                other.dns
+            } else {
+                self.dns
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -352,40 +387,5 @@ mod tests {
         assert!(result.is_err());
 
         fs::remove_dir_all(&temp_dir).unwrap();
-    }
-}
-
-impl MergeFrom<Self> for Config {
-    /// Merges another configuration into this one.
-    ///
-    /// Values from `other` will override values in `self`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dnrs::Config;
-    /// use lum_config::MergeFrom;
-    ///
-    /// let mut config = Config::default();
-    /// let mut other = Config::default();
-    /// other.resolver.ipv4.url = "https://example.com".to_string();
-    ///
-    /// let merged = config.merge_from(other);
-    /// assert_eq!(merged.resolver.ipv4.url, "https://example.com");
-    /// ```
-    fn merge_from(self, other: Self) -> Self {
-        Self {
-            resolver: other.resolver,
-            providers: if !other.providers.is_empty() {
-                other.providers
-            } else {
-                self.providers
-            },
-            dns: if !other.dns.is_empty() {
-                other.dns
-            } else {
-                self.dns
-            },
-        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,8 +46,8 @@ impl Config {
     pub fn load_from_directory(config_dir: impl AsRef<Path>) -> Result<Self, ConfigError> {
         let config_dir = config_dir.as_ref();
         let resolver = Self::load_resolver_config(config_dir)?;
-        let providers = Self::load_provider_configs(&config_dir.join("providers"))?;
-        let dns = Self::load_dns_configs(&config_dir.join("dns"))?;
+        let providers = Self::load_provider_configs(config_dir.join("providers"))?;
+        let dns = Self::load_dns_configs(config_dir.join("dns"))?;
 
         let loaded_config = Config {
             resolver,
@@ -71,7 +71,9 @@ impl Config {
         }
     }
 
-    fn load_provider_configs(providers_dir: impl AsRef<Path>) -> Result<Vec<Provider>, ConfigError> {
+    fn load_provider_configs(
+        providers_dir: impl AsRef<Path>,
+    ) -> Result<Vec<Provider>, ConfigError> {
         let providers_dir = providers_dir.as_ref();
         //TODO: Fail with error if providers config is missing
         if !providers_dir.exists() {
@@ -93,7 +95,7 @@ impl Config {
 
             if path
                 .extension()
-                .map_or(false, |ext| ext == "yaml" || ext == "yml")
+                .is_some_and(|ext| ext == "yaml" || ext == "yml")
             {
                 let content = fs::read_to_string(&path)?;
 
@@ -154,7 +156,7 @@ impl Config {
 
             if path
                 .extension()
-                .map_or(false, |ext| ext == "yaml" || ext == "yml")
+                .is_some_and(|ext| ext == "yaml" || ext == "yml")
             {
                 let content = fs::read_to_string(&path)?;
 
@@ -283,12 +285,10 @@ mod tests {
         let default_config = Config::default();
         let other = Config {
             resolver: resolver::Config::default(),
-            providers: vec![Provider::Nitrado(
-                nitrado::Config {
-                    name: "OtherNitrado".to_string(),
-                    ..Default::default()
-                },
-            )],
+            providers: vec![Provider::Nitrado(nitrado::Config {
+                name: "OtherNitrado".to_string(),
+                ..Default::default()
+            })],
             dns: vec![],
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod types;
 #[cfg(test)]
 mod cli_tests;
 
-pub use config::Config;
+pub use config::{Config, ConfigError};
 pub use logger::setup_logger;
 
 pub const PROGRAM_NAME: &str = env!("CARGO_PKG_NAME");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug};
 use std::fs;
 
-use dnrs::{Config, RuntimeError, run, setup_logger};
+use dnrs::{Config, ConfigError, RuntimeError, run, setup_logger};
 use lum_config::{ConfigPathError, EnvironmentConfigParseError, FileConfigParseError};
 use lum_log::{info, log::SetLoggerError};
 use thiserror::Error;
@@ -59,7 +59,7 @@ enum Error {
     Io(#[from] std::io::Error),
 
     #[error("Config error: {0}")]
-    Config(#[from] anyhow::Error),
+    Config(#[from] ConfigError),
 
     #[error("Unable to determine config directory")]
     NoConfigDirectory,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,13 @@ enum Error {
     ConfigIsNotDirectory,
 
     #[error("Runtime error: {0}")]
-    Runtime(#[from] RuntimeError),
+    Runtime(Box<RuntimeError>),
+}
+
+impl From<RuntimeError> for Error {
+    fn from(err: RuntimeError) -> Self {
+        Error::Runtime(Box::new(err))
+    }
 }
 
 // When main() returns an `Error`, it will be printed using the `Display` implementation

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,13 +68,7 @@ enum Error {
     ConfigIsNotDirectory,
 
     #[error("Runtime error: {0}")]
-    Runtime(Box<RuntimeError>),
-}
-
-impl From<RuntimeError> for Error {
-    fn from(err: RuntimeError) -> Self {
-        Error::Runtime(Box::new(err))
-    }
+    Runtime(#[from] RuntimeError),
 }
 
 // When main() returns an `Error`, it will be printed using the `Display` implementation
@@ -84,22 +78,22 @@ impl Debug for Error {
     }
 }
 
-fn read_config() -> Result<Config, Error> {
+fn read_config() -> Result<Config, Box<Error>> {
     let config_dir = dirs::config_dir()
-        .ok_or(Error::NoConfigDirectory)?
+        .ok_or(Box::new(Error::NoConfigDirectory))?
         .join(APP_NAME);
 
     if config_dir.exists() && !config_dir.is_dir() {
-        return Err(Error::ConfigIsNotDirectory);
+        return Err(Box::new(Error::ConfigIsNotDirectory));
     }
 
     let config = if config_dir.exists() {
-        Config::load_from_directory(&config_dir)?
+        Config::load_from_directory(&config_dir).map_err(|e| Box::new(Error::from(e)))?
     } else {
         info!("Config directory does not exist, creating default structure...");
-        fs::create_dir_all(&config_dir)?;
+        fs::create_dir_all(&config_dir).map_err(|e| Box::new(Error::from(e)))?;
 
-        Config::create_example_structure(&config_dir)?;
+        Config::create_example_structure(&config_dir).map_err(|e| Box::new(Error::from(e)))?;
         info!(
             "Created default config structure at: {}",
             config_dir.display()
@@ -114,11 +108,11 @@ fn read_config() -> Result<Config, Error> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
-    setup_logger()?;
+async fn main() -> Result<(), Box<Error>> {
+    setup_logger().map_err(|e| Box::new(Error::from(e)))?;
 
     let config = read_config()?;
-    run(config).await?;
+    run(config).await.map_err(|e| Box::new(Error::from(e)))?;
 
     Ok(())
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -91,9 +91,21 @@ pub trait Provider: Send + Sync {
         input: &GetAllRecordsInput,
     ) -> Result<Vec<Record>, ProviderError>;
 
-    async fn add_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<(), ProviderError>;
-    async fn update_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<(), ProviderError>;
-    async fn delete_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<(), ProviderError>;
+    async fn add_record(
+        &self,
+        reqwest: reqwest::Client,
+        record: &Record,
+    ) -> Result<(), ProviderError>;
+    async fn update_record(
+        &self,
+        reqwest: reqwest::Client,
+        record: &Record,
+    ) -> Result<(), ProviderError>;
+    async fn delete_record(
+        &self,
+        reqwest: reqwest::Client,
+        record: &Record,
+    ) -> Result<(), ProviderError>;
 }
 
 #[cfg(test)]
@@ -125,15 +137,27 @@ mod tests {
             Ok(self.records.clone())
         }
 
-        async fn add_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<(), ProviderError> {
+        async fn add_record(
+            &self,
+            _reqwest: reqwest::Client,
+            _record: &Record,
+        ) -> Result<(), ProviderError> {
             unimplemented!()
         }
 
-        async fn update_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<(), ProviderError> {
+        async fn update_record(
+            &self,
+            _reqwest: reqwest::Client,
+            _record: &Record,
+        ) -> Result<(), ProviderError> {
             unimplemented!()
         }
 
-        async fn delete_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<(), ProviderError> {
+        async fn delete_record(
+            &self,
+            _reqwest: reqwest::Client,
+            _record: &Record,
+        ) -> Result<(), ProviderError> {
             unimplemented!()
         }
     }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,11 +1,13 @@
-use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::types::dns::Record;
 
+pub mod error;
 pub mod hetzner;
 pub mod netcup;
 pub mod nitrado;
+
+pub use error::ProviderError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Feature {
@@ -70,12 +72,12 @@ pub trait Provider: Send + Sync {
         &self,
         reqwest: reqwest::Client,
         input: &GetRecordsInput,
-    ) -> Result<Vec<Record>> {
+    ) -> Result<Vec<Record>, ProviderError> {
         let get_all_records_input = GetAllRecordsInput::from(input);
         let records = self
             .get_all_records(reqwest, &get_all_records_input)
             .await?;
-        let records = records
+        let records: Vec<Record> = records
             .into_iter()
             .filter(|record| input.subdomains.contains(&record.domain.as_str()))
             .collect();
@@ -87,11 +89,11 @@ pub trait Provider: Send + Sync {
         &self,
         reqwest: reqwest::Client,
         input: &GetAllRecordsInput,
-    ) -> Result<Vec<Record>>;
+    ) -> Result<Vec<Record>, ProviderError>;
 
-    async fn add_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<()>;
-    async fn update_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<()>;
-    async fn delete_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<()>;
+    async fn add_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<(), ProviderError>;
+    async fn update_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<(), ProviderError>;
+    async fn delete_record(&self, reqwest: reqwest::Client, record: &Record) -> Result<(), ProviderError>;
 }
 
 #[cfg(test)]
@@ -119,19 +121,19 @@ mod tests {
             &self,
             _reqwest: reqwest::Client,
             _input: &GetAllRecordsInput,
-        ) -> Result<Vec<Record>> {
+        ) -> Result<Vec<Record>, ProviderError> {
             Ok(self.records.clone())
         }
 
-        async fn add_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<()> {
+        async fn add_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<(), ProviderError> {
             unimplemented!()
         }
 
-        async fn update_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<()> {
+        async fn update_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<(), ProviderError> {
             unimplemented!()
         }
 
-        async fn delete_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<()> {
+        async fn delete_record(&self, _reqwest: reqwest::Client, _record: &Record) -> Result<(), ProviderError> {
             unimplemented!()
         }
     }

--- a/src/provider/error.rs
+++ b/src/provider/error.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+
+use crate::provider::{hetzner, netcup, nitrado};
+
+/// Error type for all DNS provider operations.
+///
+/// This enum wraps provider-specific errors and common failure cases,
+/// providing a unified error type for the provider trait.
+#[derive(Debug, Error)]
+pub enum ProviderError {
+    /// Error from Hetzner DNS provider
+    #[error("Hetzner provider error: {0}")]
+    Hetzner(#[from] hetzner::Error),
+
+    /// Error from Nitrado DNS provider
+    #[error("Nitrado provider error: {0}")]
+    Nitrado(#[from] nitrado::Error),
+
+    /// Error from Netcup DNS provider
+    #[error("Netcup provider error: {0}")]
+    Netcup(#[from] netcup::Error),
+
+    /// HTTP request failed
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// JSON parsing error
+    #[error("JSON parsing error: {0}")]
+    Json(#[from] lum_libs::serde_json::Error),
+
+    /// Invalid API key format for HTTP headers
+    #[error("Invalid API key: contains characters not allowed in HTTP headers")]
+    InvalidApiKey,
+
+    /// Record conversion error
+    #[error("Failed to convert record: {0}")]
+    RecordConversion(String),
+}

--- a/src/provider/error.rs
+++ b/src/provider/error.rs
@@ -31,8 +31,4 @@ pub enum ProviderError {
     /// Invalid API key format for HTTP headers
     #[error("Invalid API key: contains characters not allowed in HTTP headers")]
     InvalidApiKey,
-
-    /// Record conversion error
-    #[error("Failed to convert record: {0}")]
-    RecordConversion(String),
 }

--- a/src/provider/error.rs
+++ b/src/provider/error.rs
@@ -19,20 +19,91 @@ pub enum ProviderError {
     /// Error from Netcup DNS provider
     #[error("Netcup provider error: {0}")]
     Netcup(#[from] netcup::Error),
+}
 
-    /// HTTP request failed
-    #[error("HTTP request failed: {0}")]
-    Http(#[from] reqwest::Error),
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lum_libs::serde_json;
 
-    /// JSON parsing error
-    #[error("JSON parsing error: {0}")]
-    Json(#[from] lum_libs::serde_json::Error),
+    #[test]
+    fn test_hetzner_error_display() {
+        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
+        let err = hetzner::Error::Json(json_err);
+        let display = format!("{}", err);
+        assert!(display.contains("JSON parsing error"));
+    }
 
-    /// Invalid API key format for HTTP headers
-    #[error("Invalid API key: contains characters not allowed in HTTP headers")]
-    InvalidApiKey,
+    #[test]
+    fn test_hetzner_domain_not_found_display() {
+        let err = hetzner::Error::DomainNotFound("example.com".to_string());
+        let display = format!("{}", err);
+        assert_eq!(display, "Domain 'example.com' not found in Hetzner zones");
+    }
 
-    /// Record conversion error
-    #[error("Failed to convert record: {0}")]
-    RecordConversion(String),
+    #[test]
+    fn test_nitrado_error_display() {
+        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
+        let err = nitrado::Error::Json(json_err);
+        let display = format!("{}", err);
+        assert!(display.contains("JSON parsing error"));
+    }
+
+    #[test]
+    fn test_netcup_error_display() {
+        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
+        let err = netcup::Error::Json(json_err);
+        let display = format!("{}", err);
+        assert!(display.contains("JSON parsing error"));
+    }
+
+    #[test]
+    fn test_netcup_domain_not_found_display() {
+        let err = netcup::Error::DomainNotFound("example.com".to_string());
+        let display = format!("{}", err);
+        assert_eq!(display, "Domain 'example.com' not found in Netcup zones");
+    }
+
+    #[test]
+    fn test_provider_error_from_hetzner() {
+        let hetzner_err = hetzner::Error::DomainNotFound("example.com".to_string());
+        let provider_err: ProviderError = hetzner_err.into();
+
+        assert!(matches!(provider_err, ProviderError::Hetzner(_)));
+        let display = format!("{}", provider_err);
+        assert!(display.contains("Hetzner provider error"));
+        assert!(display.contains("example.com"));
+    }
+
+    #[test]
+    fn test_provider_error_from_nitrado() {
+        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
+        let nitrado_err = nitrado::Error::Json(json_err);
+        let provider_err: ProviderError = nitrado_err.into();
+
+        assert!(matches!(provider_err, ProviderError::Nitrado(_)));
+        let display = format!("{}", provider_err);
+        assert!(display.contains("Nitrado provider error"));
+    }
+
+    #[test]
+    fn test_provider_error_from_netcup() {
+        let netcup_err = netcup::Error::DomainNotFound("test.org".to_string());
+        let provider_err: ProviderError = netcup_err.into();
+
+        assert!(matches!(provider_err, ProviderError::Netcup(_)));
+        let display = format!("{}", provider_err);
+        assert!(display.contains("Netcup provider error"));
+        assert!(display.contains("test.org"));
+    }
+
+    #[test]
+    fn test_provider_error_debug() {
+        let hetzner_err = hetzner::Error::DomainNotFound("debug-test.com".to_string());
+        let provider_err: ProviderError = hetzner_err.into();
+
+        let debug = format!("{:?}", provider_err);
+        assert!(debug.contains("Hetzner"));
+        assert!(debug.contains("DomainNotFound"));
+    }
 }

--- a/src/provider/hetzner.rs
+++ b/src/provider/hetzner.rs
@@ -122,15 +122,15 @@ impl Provider for HetznerProvider<'_> {
             .headers(headers)
             .send()
             .await
-            .map_err(Error::from)?;
+            .map_err(Error::Reqwest)?;
 
         if !response.status().is_success() {
             return Err(Error::Unsuccessful(response.status().as_u16(), response).into());
         }
 
-        let text = response.text().await.map_err(Error::from)?;
-        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(Error::from)?;
-        let records: Vec<dns::Record> = response.try_into().map_err(Error::from)?;
+        let text = response.text().await.map_err(Error::Reqwest)?;
+        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(Error::Json)?;
+        let records: Vec<dns::Record> = response.try_into().map_err(Error::RecordConversion)?;
 
         Ok(records)
     }

--- a/src/provider/hetzner.rs
+++ b/src/provider/hetzner.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use async_trait::async_trait;
 use lum_libs::serde_json;
 use reqwest::header::HeaderMap;
 use thiserror::Error;
 
 use crate::{
-    provider::{Feature, GetAllRecordsInput, Provider},
+    provider::{Feature, GetAllRecordsInput, Provider, ProviderError},
     types::dns::{self},
 };
 
@@ -24,7 +23,7 @@ impl<'provider_config> HetznerProvider<'provider_config> {
         HetznerProvider { provider_config }
     }
 
-    async fn get_zone_id(&self, reqwest: reqwest::Client, domain: &str) -> Result<String> {
+    async fn get_zone_id(&self, reqwest: reqwest::Client, domain: &str) -> Result<String, Error> {
         let mut headers = HeaderMap::new();
         headers.insert(
             "Auth-API-Token",
@@ -35,7 +34,7 @@ impl<'provider_config> HetznerProvider<'provider_config> {
         let response = reqwest.get(&url).headers(headers).send().await?;
 
         if !response.status().is_success() {
-            return Err(Error::Unsuccessful(response.status().as_u16(), response).into());
+            return Err(Error::Unsuccessful(response.status().as_u16(), response));
         }
 
         let text = response.text().await?;
@@ -56,7 +55,7 @@ impl<'provider_config> HetznerProvider<'provider_config> {
                 })
             }) {
             Some(zone_id) => Ok(zone_id),
-            None => Err(Error::DomainNotFound(domain.to_string()).into()),
+            None => Err(Error::DomainNotFound(domain.to_string())),
         }
     }
 }
@@ -74,6 +73,9 @@ pub enum Error {
 
     #[error("Domain '{0}' not found in Hetzner zones")]
     DomainNotFound(String),
+
+    #[error("Record conversion error: {0}")]
+    RecordConversion(#[from] TryFromRecordError),
 }
 
 #[async_trait]
@@ -97,7 +99,7 @@ impl Provider for HetznerProvider<'_> {
         &self,
         reqwest: reqwest::Client,
         input: &GetAllRecordsInput,
-    ) -> Result<Vec<dns::Record>> {
+    ) -> Result<Vec<dns::Record>, ProviderError> {
         let mut headers = HeaderMap::new();
         headers.insert(
             "Auth-API-Token",
@@ -105,7 +107,7 @@ impl Provider for HetznerProvider<'_> {
         );
 
         let domain = &input.domain;
-        let zone_id = self.get_zone_id(reqwest.clone(), domain).await?;
+        let zone_id = self.get_zone_id(reqwest.clone(), domain).await.map_err(ProviderError::Hetzner)?;
 
         let url = format!(
             "{}/records?zone_id={}",
@@ -115,25 +117,25 @@ impl Provider for HetznerProvider<'_> {
         let response = reqwest.get(&url).headers(headers).send().await?;
 
         if !response.status().is_success() {
-            return Err(Error::Unsuccessful(response.status().as_u16(), response).into());
+            return Err(ProviderError::Hetzner(Error::Unsuccessful(response.status().as_u16(), response)));
         }
 
-        let text = response.text().await?;
-        let response: GetRecordsResponse = serde_json::from_str(&text)?;
-        let records: Vec<dns::Record> = response.try_into()?;
+        let text = response.text().await.map_err(ProviderError::Http)?;
+        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(ProviderError::Json)?;
+        let records: Vec<dns::Record> = response.try_into().map_err(|e: TryFromRecordError| ProviderError::Hetzner(Error::RecordConversion(e)))?;
 
         Ok(records)
     }
 
-    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!("Hetzner add_record not yet implemented")
     }
 
-    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!("Hetzner update_record not yet implemented")
     }
 
-    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!("Hetzner delete_record not yet implemented")
     }
 }

--- a/src/provider/hetzner.rs
+++ b/src/provider/hetzner.rs
@@ -27,7 +27,9 @@ impl<'provider_config> HetznerProvider<'provider_config> {
         let mut headers = HeaderMap::new();
         headers.insert(
             "Auth-API-Token",
-            self.provider_config.api_key.parse().expect("Invalid Hetzner API key: contains characters that are not allowed in HTTP headers"),
+            self.provider_config.api_key.parse().expect(
+                "Invalid Hetzner API key: contains characters that are not allowed in HTTP headers",
+            ),
         );
 
         let url = format!("{}/zones", self.provider_config.api_base_url);
@@ -94,7 +96,6 @@ impl Provider for HetznerProvider<'_> {
         ]
     }
 
-
     async fn get_all_records(
         &self,
         reqwest: reqwest::Client,
@@ -103,39 +104,58 @@ impl Provider for HetznerProvider<'_> {
         let mut headers = HeaderMap::new();
         headers.insert(
             "Auth-API-Token",
-            self.provider_config.api_key.parse().expect("Invalid Hetzner API key: contains characters that are not allowed in HTTP headers"),
+            self.provider_config.api_key.parse().expect(
+                "Invalid Hetzner API key: contains characters that are not allowed in HTTP headers",
+            ),
         );
 
         let domain = &input.domain;
-        let zone_id = self.get_zone_id(reqwest.clone(), domain).await.map_err(ProviderError::Hetzner)?;
+        let zone_id = self.get_zone_id(reqwest.clone(), domain).await?;
 
         let url = format!(
             "{}/records?zone_id={}",
             self.provider_config.api_base_url, zone_id
         );
 
-        let response = reqwest.get(&url).headers(headers).send().await?;
+        let response = reqwest
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(Error::from)?;
 
         if !response.status().is_success() {
-            return Err(ProviderError::Hetzner(Error::Unsuccessful(response.status().as_u16(), response)));
+            return Err(Error::Unsuccessful(response.status().as_u16(), response).into());
         }
 
-        let text = response.text().await.map_err(ProviderError::Http)?;
-        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(ProviderError::Json)?;
-        let records: Vec<dns::Record> = response.try_into().map_err(|e: TryFromRecordError| ProviderError::Hetzner(Error::RecordConversion(e)))?;
+        let text = response.text().await.map_err(Error::from)?;
+        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(Error::from)?;
+        let records: Vec<dns::Record> = response.try_into().map_err(Error::from)?;
 
         Ok(records)
     }
 
-    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn add_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!("Hetzner add_record not yet implemented")
     }
 
-    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn update_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!("Hetzner update_record not yet implemented")
     }
 
-    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn delete_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!("Hetzner delete_record not yet implemented")
     }
 }

--- a/src/provider/hetzner.rs
+++ b/src/provider/hetzner.rs
@@ -114,7 +114,12 @@ impl Provider for HetznerProvider<'_> {
             self.provider_config.api_base_url, zone_id
         );
 
-        let response = reqwest.get(&url).headers(headers).send().await?;
+        let response = reqwest
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(ProviderError::Http)?;
 
         if !response.status().is_success() {
             return Err(ProviderError::Hetzner(Error::Unsuccessful(response.status().as_u16(), response)));

--- a/src/provider/netcup.rs
+++ b/src/provider/netcup.rs
@@ -1,10 +1,9 @@
-use anyhow::Result;
 use async_trait::async_trait;
 use lum_libs::serde_json;
 use thiserror::Error;
 
 use crate::{
-    provider::{Feature, GetAllRecordsInput, Provider},
+    provider::{Feature, GetAllRecordsInput, Provider, ProviderError},
     types::dns::{self},
 };
 
@@ -37,6 +36,9 @@ pub enum Error {
 
     #[error("Domain '{0}' not found in Netcup zones")]
     DomainNotFound(String),
+
+    #[error("Record conversion error: {0}")]
+    RecordConversion(#[from] TryFromRecordError),
 }
 
 #[async_trait]
@@ -60,19 +62,19 @@ impl Provider for NetcupProvider<'_> {
         &self,
         _reqwest: reqwest::Client,
         _input: &GetAllRecordsInput,
-    ) -> Result<Vec<dns::Record>> {
+    ) -> Result<Vec<dns::Record>, ProviderError> {
         unimplemented!("Netcup get_all_records not yet implemented")
     }
 
-    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!("Netcup add_record not yet implemented")
     }
 
-    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!("Netcup update_record not yet implemented")
     }
 
-    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!("Netcup delete_record not yet implemented")
     }
 }

--- a/src/provider/netcup.rs
+++ b/src/provider/netcup.rs
@@ -57,7 +57,6 @@ impl Provider for NetcupProvider<'_> {
         ]
     }
 
-
     async fn get_all_records(
         &self,
         _reqwest: reqwest::Client,
@@ -66,15 +65,27 @@ impl Provider for NetcupProvider<'_> {
         unimplemented!("Netcup get_all_records not yet implemented")
     }
 
-    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn add_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!("Netcup add_record not yet implemented")
     }
 
-    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn update_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!("Netcup update_record not yet implemented")
     }
 
-    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn delete_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!("Netcup delete_record not yet implemented")
     }
 }

--- a/src/provider/nitrado.rs
+++ b/src/provider/nitrado.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use async_trait::async_trait;
 use lum_libs::serde_json;
 use reqwest::header::HeaderMap;
 use thiserror::Error;
 
 use crate::{
-    provider::{Feature, GetAllRecordsInput, Provider},
+    provider::{Feature, GetAllRecordsInput, Provider, ProviderError},
     types::dns::{self},
 };
 
@@ -35,6 +34,9 @@ pub enum Error {
 
     #[error("JSON parsing error: {0}")]
     Json(#[from] serde_json::Error),
+
+    #[error("Record conversion error: {0}")]
+    RecordConversion(#[from] TryFromRecordError),
 }
 
 #[async_trait]
@@ -57,7 +59,7 @@ impl Provider for NitradoProvider<'_> {
         &self,
         reqwest: reqwest::Client,
         input: &GetAllRecordsInput,
-    ) -> Result<Vec<dns::Record>> {
+    ) -> Result<Vec<dns::Record>, ProviderError> {
         let mut headers = HeaderMap::new();
         headers.insert(
             "Authorization",
@@ -71,28 +73,28 @@ impl Provider for NitradoProvider<'_> {
             "{}/domain/{}/records",
             self.provider_config.api_base_url, domain
         );
-        let response = reqwest.get(&url).headers(headers).send().await?;
+        let response = reqwest.get(&url).headers(headers).send().await.map_err(ProviderError::Http)?;
 
         if !response.status().is_success() {
-            return Err(Error::Unsuccessful(response.status().as_u16(), response).into());
+            return Err(ProviderError::Nitrado(Error::Unsuccessful(response.status().as_u16(), response)));
         }
 
-        let text = response.text().await?;
-        let response: GetRecordsResponse = serde_json::from_str(&text)?;
-        let records: Vec<dns::Record> = response.try_into()?;
+        let text = response.text().await.map_err(ProviderError::Http)?;
+        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(ProviderError::Json)?;
+        let records: Vec<dns::Record> = response.try_into().map_err(|e: TryFromRecordError| ProviderError::Nitrado(Error::RecordConversion(e)))?;
 
         Ok(records)
     }
 
-    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!()
     }
 
-    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!()
     }
 
-    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<()> {
+    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
         unimplemented!()
     }
 }

--- a/src/provider/nitrado.rs
+++ b/src/provider/nitrado.rs
@@ -73,28 +73,45 @@ impl Provider for NitradoProvider<'_> {
             "{}/domain/{}/records",
             self.provider_config.api_base_url, domain
         );
-        let response = reqwest.get(&url).headers(headers).send().await.map_err(ProviderError::Http)?;
+        let response = reqwest
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(Error::from)?;
 
         if !response.status().is_success() {
-            return Err(ProviderError::Nitrado(Error::Unsuccessful(response.status().as_u16(), response)));
+            return Err(Error::Unsuccessful(response.status().as_u16(), response).into());
         }
 
-        let text = response.text().await.map_err(ProviderError::Http)?;
-        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(ProviderError::Json)?;
-        let records: Vec<dns::Record> = response.try_into().map_err(|e: TryFromRecordError| ProviderError::Nitrado(Error::RecordConversion(e)))?;
+        let text = response.text().await.map_err(Error::from)?;
+        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(Error::from)?;
+        let records: Vec<dns::Record> = response.try_into().map_err(Error::from)?;
 
         Ok(records)
     }
 
-    async fn add_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn add_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!()
     }
 
-    async fn update_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn update_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!()
     }
 
-    async fn delete_record(&self, _reqwest: reqwest::Client, _input: &dns::Record) -> Result<(), ProviderError> {
+    async fn delete_record(
+        &self,
+        _reqwest: reqwest::Client,
+        _input: &dns::Record,
+    ) -> Result<(), ProviderError> {
         unimplemented!()
     }
 }

--- a/src/provider/nitrado.rs
+++ b/src/provider/nitrado.rs
@@ -78,15 +78,15 @@ impl Provider for NitradoProvider<'_> {
             .headers(headers)
             .send()
             .await
-            .map_err(Error::from)?;
+            .map_err(Error::Reqwest)?;
 
         if !response.status().is_success() {
             return Err(Error::Unsuccessful(response.status().as_u16(), response).into());
         }
 
-        let text = response.text().await.map_err(Error::from)?;
-        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(Error::from)?;
-        let records: Vec<dns::Record> = response.try_into().map_err(Error::from)?;
+        let text = response.text().await.map_err(Error::Reqwest)?;
+        let response: GetRecordsResponse = serde_json::from_str(&text).map_err(Error::Json)?;
+        let records: Vec<dns::Record> = response.try_into().map_err(Error::RecordConversion)?;
 
         Ok(records)
     }


### PR DESCRIPTION
This pull request refactors error handling throughout the codebase to replace the use of the generic `anyhow::Error` with custom, strongly-typed error enums for configuration and provider-related operations. This makes error handling more precise and improves error reporting. The most significant changes include the introduction of `ConfigError` and `ProviderError` types, their integration into the main application logic, and the propagation of these error types through the CLI and provider interfaces.

**Error Handling Refactor:**

* Introduced a new `ConfigError` enum in `src/config.rs` to handle configuration loading and parsing errors, replacing `anyhow::Error` throughout the configuration code. All relevant functions now return `Result<T, ConfigError>` and propagate this error type. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL1-R5) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR16-R31) [[3]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL31-R50) [[4]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL47-R62) [[5]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL59-R76) [[6]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL81-R98) [[7]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL108-R125) [[8]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL123-R140) [[9]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL142-R159) [[10]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL165-R182) [[11]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL177-R191) [[12]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L18-R18) [[13]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL4-R4) [[14]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL62-R62)
* Added a new `ProviderError` enum in `src/provider/error.rs` that unifies errors from all DNS providers and is now used as the error type for the `Provider` trait methods. All provider implementations and trait signatures have been updated to use this error type instead of `anyhow::Error`. [[1]](diffhunk://#diff-ac2ac359957203dd5b34f40737b4580ff70e166d887226350d589f985f86a375L1-R11) [[2]](diffhunk://#diff-ac2ac359957203dd5b34f40737b4580ff70e166d887226350d589f985f86a375L73-R80) [[3]](diffhunk://#diff-ac2ac359957203dd5b34f40737b4580ff70e166d887226350d589f985f86a375L90-R108) [[4]](diffhunk://#diff-ac2ac359957203dd5b34f40737b4580ff70e166d887226350d589f985f86a375L122-R160) [[5]](diffhunk://#diff-1051fcc5963bc0120729afd624a3a195974e948c2ac0e96a8ba02d6c0e1e7ec2R1-R109) [[6]](diffhunk://#diff-c10a884ac890eab11a1549cc0f0978205029a47b7d89c4ae499706d5d86e3fa7L1-R7)

**CLI and Application Logic Adjustments:**

* Updated CLI commands and error enums to use the new `ConfigError` and `ProviderError` types, improving the specificity of error messages shown to users. Added new error variants for argument validation in `src/cli/get.rs`. [[1]](diffhunk://#diff-2b7a41293d17bde051fc10e5fc1841f8dbc1e676f7bbc298a321938ac7ecc2b6L12-R12) [[2]](diffhunk://#diff-2b7a41293d17bde051fc10e5fc1841f8dbc1e676f7bbc298a321938ac7ecc2b6L29-R35) [[3]](diffhunk://#diff-2b7a41293d17bde051fc10e5fc1841f8dbc1e676f7bbc298a321938ac7ecc2b6L97-R108) [[4]](diffhunk://#diff-65534b463bc66be396a246d2f77bd9e55b2d512b02b4099a7031178ab4042ca0L7-R7) [[5]](diffhunk://#diff-65534b463bc66be396a246d2f77bd9e55b2d512b02b4099a7031178ab4042ca0L23-R23)
* Updated the main application error handling in `src/main.rs` to integrate the new error types, including a small change to box `RuntimeError` for consistency. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL62-R62) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL71-R77)

**Dependency and Code Clean-up:**

* Removed the dependency on `anyhow` in `Cargo.toml` and all code files, as it is no longer needed after migrating to custom error types. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL1-R5) [[3]](diffhunk://#diff-c10a884ac890eab11a1549cc0f0978205029a47b7d89c4ae499706d5d86e3fa7L1-R7)

These changes collectively improve the robustness and clarity of error handling across the application, making it easier to diagnose and handle specific error cases.